### PR TITLE
fix: switch auth from OAuth to IAM token or SA key

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker build -t stupean/yandex-terraform:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: "stupean/yandex-terraform:${{ github.sha }}"
           format: "template"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 # Install essential utilities with pinned versions
 RUN apk add --no-cache \
-    curl=8.14.1-r2 \
+    curl=8.14.1-r3 \
     bash=5.2.37-r0 \
     && addgroup -g 1000 -S appgroup \
     && adduser -S appuser -u 1000 -G appgroup

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Docker container provides a ready-to-use environment for working with Yande
 
 - Docker installed on your system
 - Yandex Cloud account with appropriate permissions
-- OAuth token for Yandex Cloud API access
+- [IAM token](https://yandex.cloud/en/docs/iam/concepts/authorization/iam-token) or [service account key](https://yandex.cloud/en/docs/iam/concepts/authorization/key) (OAuth tokens are no longer supported)
 
 ## Getting Started
 
@@ -37,12 +37,21 @@ cd my-terraform-project
 
 ### 3. Obtain Yandex Cloud Credentials
 
-| Variable       | Description                                                                                     | Required |
-| -------------- | ----------------------------------------------------------------------------------------------- | -------- |
-| `YC_TOKEN`     | [Yandex Cloud OAuth token](https://yandex.cloud/en/docs/iam/concepts/authorization/oauth-token) | Yes      |
-| `YC_CLOUD_ID`  | Yandex Cloud ID                                                                                 | No       |
-| `YC_FOLDER_ID` | Yandex Cloud Folder ID                                                                          | No       |
-| `YC_ZONE`      | Default zone (default: ru-central1-a)                                                           | No       |
+| Variable                      | Description                                                                                          | Required |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
+| `YC_TOKEN`                    | [IAM token](https://yandex.cloud/en/docs/iam/operations/iam-token/create) (`yc iam create-token`)   | Yes\*    |
+| `YC_SERVICE_ACCOUNT_KEY_FILE` | Path to [service account authorized key](https://yandex.cloud/en/docs/iam/operations/authorized-key/create) JSON | Yes\*    |
+| `YC_CLOUD_ID`                 | Yandex Cloud ID                                                                                      | No       |
+| `YC_FOLDER_ID`                | Yandex Cloud Folder ID                                                                               | No       |
+| `YC_ZONE`                     | Default zone (default: ru-central1-a)                                                                | No       |
+
+\*Provide either `YC_TOKEN` or `YC_SERVICE_ACCOUNT_KEY_FILE` (not both required). IAM tokens expire within ~12 hours.
+
+Get an IAM token:
+
+```bash
+export YC_TOKEN=$(yc iam create-token)
+```
 
 ### 4. Basic Usage
 
@@ -50,7 +59,7 @@ cd my-terraform-project
 
 ```bash
 docker run -it --rm \
-  -e YC_TOKEN=your_oauth_token_here \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -e YC_CLOUD_ID=your_cloud_id_here \
   -e YC_FOLDER_ID=your_folder_id_here \
   -v $(pwd):/app \
@@ -62,7 +71,7 @@ docker run -it --rm \
 ```bash
 # Initialize Terraform
 docker run -it --rm \
-  -e YC_TOKEN=your_token \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -e YC_CLOUD_ID=your_cloud_id \
   -e YC_FOLDER_ID=your_folder_id \
   -v $(pwd):/app \
@@ -70,7 +79,7 @@ docker run -it --rm \
 
 # Plan infrastructure changes
 docker run -it --rm \
-  -e YC_TOKEN=your_token \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -e YC_CLOUD_ID=your_cloud_id \
   -e YC_FOLDER_ID=your_folder_id \
   -v $(pwd):/app \
@@ -78,7 +87,7 @@ docker run -it --rm \
 
 # Apply changes
 docker run -it --rm \
-  -e YC_TOKEN=your_token \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -e YC_CLOUD_ID=your_cloud_id \
   -e YC_FOLDER_ID=your_folder_id \
   -v $(pwd):/app \
@@ -86,11 +95,20 @@ docker run -it --rm \
 
 # Destroy infrastructure
 docker run -it --rm \
-  -e YC_TOKEN=your_token \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -e YC_CLOUD_ID=your_cloud_id \
   -e YC_FOLDER_ID=your_folder_id \
   -v $(pwd):/app \
   yandex-terraform destroy
+
+# Authenticate with a service account key instead of an IAM token
+docker run -it --rm \
+  -e YC_SERVICE_ACCOUNT_KEY_FILE=/keys/sa-key.json \
+  -e YC_CLOUD_ID=your_cloud_id \
+  -e YC_FOLDER_ID=your_folder_id \
+  -v $(pwd):/app \
+  -v /path/to/sa-key.json:/keys/sa-key.json:ro \
+  yandex-terraform plan
 ```
 
 ## Volume Mounting
@@ -105,9 +123,11 @@ Mount your local directory to `/app` in the container to persist Terraform state
 
 ### Common Issues
 
-1. **"YC_TOKEN must be set" error**: Ensure you pass the YC_TOKEN environment variable
-2. **Permission errors**: Check that your token has sufficient permissions in Yandex Cloud
-3. **Network issues**: Verify you can access Yandex Cloud APIs from your network
+1. **"YC_TOKEN or YC_SERVICE_ACCOUNT_KEY_FILE must be set"**: Pass an IAM token or mount a service account key
+2. **"OAuth tokens are no longer supported"**: Use `yc iam create-token` instead of an OAuth token
+3. **Permission errors**: Check that your token/key has sufficient permissions in Yandex Cloud
+4. **Network issues**: Verify you can access Yandex Cloud APIs from your network
+5. **IAM token expired**: IAM tokens live up to ~12 hours; create a new one with `yc iam create-token`
 
 ### Debug Mode
 
@@ -115,7 +135,7 @@ Run container with debug output:
 
 ```bash
 docker run -it --rm \
-  -e YC_TOKEN=your_token \
+  -e YC_TOKEN="$(yc iam create-token)" \
   -v $(pwd):/app \
   yandex-terraform plan -verbose
 ```

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Проверка обязательных переменных
-if [[ -z ${YC_TOKEN} ]]; then
-	echo "Error: YC_TOKEN must be set"
+# Yandex Cloud OAuth tokens are no longer accepted for new auth (since 2026-06-01).
+# Terraform provider expects an IAM token in YC_TOKEN, or a service account key file.
+# See: https://yandex.cloud/en/docs/terraform/authentication
+
+if [[ -z "${YC_TOKEN:-}" && -z "${YC_SERVICE_ACCOUNT_KEY_FILE:-}" ]]; then
+	echo "Error: YC_TOKEN or YC_SERVICE_ACCOUNT_KEY_FILE must be set"
 	exit 1
 fi
 
-yc config set token "${YC_TOKEN}"
-yc iam whoami # initialize yc
+if [[ -n "${YC_SERVICE_ACCOUNT_KEY_FILE:-}" ]]; then
+	if [[ ! -f "${YC_SERVICE_ACCOUNT_KEY_FILE}" ]]; then
+		echo "Error: YC_SERVICE_ACCOUNT_KEY_FILE does not exist: ${YC_SERVICE_ACCOUNT_KEY_FILE}"
+		exit 1
+	fi
+	# Provider accepts only one auth method; prefer the key file when both are present.
+	unset YC_TOKEN
+	yc config set service-account-key "${YC_SERVICE_ACCOUNT_KEY_FILE}"
+elif [[ "${YC_TOKEN}" == y[0-3]_* ]]; then
+	echo "Error: OAuth tokens are no longer supported. Use an IAM token from 'yc iam create-token' (YC_TOKEN) or a service account key (YC_SERVICE_ACCOUNT_KEY_FILE)."
+	exit 1
+elif [[ "${YC_TOKEN}" != t1.* ]]; then
+	echo "Warning: YC_TOKEN does not look like an IAM token (expected prefix 't1.'). Continuing anyway."
+fi
+
+if [[ -n "${YC_CLOUD_ID:-}" ]]; then
+	yc config set cloud-id "${YC_CLOUD_ID}"
+fi
+
+if [[ -n "${YC_FOLDER_ID:-}" ]]; then
+	yc config set folder-id "${YC_FOLDER_ID}"
+fi
 
 exec /bin/terraform "$@"

--- a/tests/validate-yc-token.sh
+++ b/tests/validate-yc-token.sh
@@ -17,7 +17,7 @@ output=$(docker run --rm "$IMAGE_TAG" version 2>&1 || true)
 echo "📥 Raw output:"
 echo "$output"
 
-expected_msg="Error: YC_TOKEN must be set"
+expected_msg="Error: YC_TOKEN or YC_SERVICE_ACCOUNT_KEY_FILE must be set"
 echo "🔍 Checking for expected error message: '$expected_msg'"
 
 if echo "$output" | grep -q "$expected_msg"; then


### PR DESCRIPTION
OAuth tokens are no longer accepted by Yandex Cloud; accept IAM tokens and service account keys, and document the new flow.